### PR TITLE
Fix stderr not being checked in test1

### DIFF
--- a/.grade/test1.sh
+++ b/.grade/test1.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-.tmp/Picat/picat boardomino.pi 8 "[{1,1},{8,8}]" &> output.txt
-cat output.txt
+.tmp/Picat/picat boardomino.pi 8 "[{1,1},{8,8}]" 2>&1
+exit 0


### PR DESCRIPTION
The default `failed` string is present in stderr and not stdout, hence it is not being sent to the autograder currently. This PR fixes the issue by redirecting stderr to stdout and then exiting with error code 0 (the autograder rejects solutions exiting with non-zero error code by default and failing in picat emits error code 1).