### PR TITLE
Add MIP support to the autograder

### DIFF
--- a/.grade/setup.sh
+++ b/.grade/setup.sh
@@ -3,4 +3,4 @@ rm -rf .tmp
 mkdir .tmp
 wget -q -O .tmp/picat.tar.gz http://picat-lang.org/download/picat328_linux64.tar.gz
 tar -xf .tmp/picat.tar.gz -C .tmp
-
+sudo apt-get install -y coinor-cbc coinor-libcbc-dev

--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ picat boardomino.pi 8 "[{1,1},{8,8}]"
 ```
 Try different models and solvers and choose the best option based on the performance on the unsatisfiable instances of the form `n [{1,1},{n,n}]`. (Your program should not be much slower than the best one.)
 
-NOTE: If you use the mip solver, all tests will fail (as the external MIP solver won't be found).
+UPDATED NOTE: Using the mip solver will no longer fail all your tests, they should be checked correctly.


### PR DESCRIPTION
Currently the MIP solver cannot be used as it requires external dependencies (as was mentioned on the practical). This PR fixes that issue by running the relevant apt command in setup.sh.